### PR TITLE
Support more `ServerProxy` options.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.3.0 (unreleased)
 ==================
 
-- Support options `use_datetime` (`Python >= 2.7`) and `use_builtin_types`
+- Support options *use_datetime* (Python >= 2.7) and *use_builtin_types* 
+ (Python >= 3.5) of ``ServerProxy``.
   (`Python >= 3.5`) of ``ServerProxy``.
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,8 @@
 4.3.0 (unreleased)
 ==================
 
-- Support options *use_datetime* (Python >= 2.7) and *use_builtin_types* 
- (Python >= 3.5) of ``ServerProxy``.
-  (`Python >= 3.5`) of ``ServerProxy``.
+- Support options *use_datetime* (Python >= 2.7) and *use_builtin_types*
+  (`Python >= 3.5`) in ``.xmlrpc.testing.ServerProxy``.
 
 
 4.2.0 (2019-12-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 4.3.0 (unreleased)
 ==================
 
-- Support options `use_datetime` and `use_builtin_types` of ``ServerProxy``.
+- Support options `use_datetime` (`Python >= 2.7`) and `use_builtin_types`
+  (`Python >= 3.5`) of ``ServerProxy``.
 
 
 4.2.0 (2019-12-05)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.3.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Support options `use_datetime` and `use_builtin_types` of ``ServerProxy``.
 
 
 4.2.0 (2019-12-05)

--- a/setup.py
+++ b/setup.py
@@ -111,10 +111,7 @@ setup(name='zope.app.publisher',
       ],
       extras_require={
           'test': tests_require,
-          'testing': [
-              'six',
-              'zope.app.wsgi',
-          ]
+          'testing': 'zope.app.wsgi',
       },
       tests_require=tests_require,
       zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,10 @@ setup(name='zope.app.publisher',
       ],
       extras_require={
           'test': tests_require,
-          'testing': 'zope.app.wsgi',
+          'testing': [
+              'six',
+              'zope.app.wsgi',
+          ]
       },
       tests_require=tests_require,
       zip_safe=False,

--- a/src/zope/app/publisher/xmlrpc/testing.py
+++ b/src/zope/app/publisher/xmlrpc/testing.py
@@ -1,15 +1,14 @@
 try:
     import xmlrpclib
-except ImportError:
+except ImportError:  # PY3
     import xmlrpc.client as xmlrpclib
 
 try:
     import httplib
-except ImportError:
+except ImportError:  # PY3
     import http.client as httplib
 
 from io import BytesIO
-import six
 
 from zope.app.wsgi.testlayer import http as _http
 
@@ -89,14 +88,15 @@ class ZopeTestTransport(xmlrpclib.Transport):
 
 def ServerProxy(wsgi_app, uri, transport=None, encoding=None,
                 verbose=0, allow_none=0, handleErrors=True,
-                use_datetime=False, use_builtin_types=False):
-    """A factory that creates a server proxy using the ZopeTestTransport
-    by default.
+                **transport_options):
+    """A factory that creates a server proxy.
+
+    If ``transport`` is ``None`` use the ``ZopeTestTransport``, it gets
+    initialized with ``**transport_options``. Which options are supported
+    depends on the used Python version, see
+    ``xmlrpc.client.Transport.__init__`` resp. ``xmlrpclib.Transport.__init__``
+    for details.
     """
-    transport_options = dict(use_datetime=use_datetime)
-    if six.PY3:
-        # use_builtin_types is only available since 3.3
-        transport_options['use_builtin_types'] = use_builtin_types
     if transport is None:
         transport = ZopeTestTransport(**transport_options)
         transport.wsgi_app = wsgi_app

--- a/src/zope/app/publisher/xmlrpc/testing.py
+++ b/src/zope/app/publisher/xmlrpc/testing.py
@@ -9,6 +9,7 @@ except ImportError:
     import http.client as httplib
 
 from io import BytesIO
+import six
 
 from zope.app.wsgi.testlayer import http as _http
 
@@ -87,12 +88,17 @@ class ZopeTestTransport(xmlrpclib.Transport):
 
 
 def ServerProxy(wsgi_app, uri, transport=None, encoding=None,
-                verbose=0, allow_none=0, handleErrors=True):
+                verbose=0, allow_none=0, handleErrors=True,
+                use_datetime=False, use_builtin_types=False):
     """A factory that creates a server proxy using the ZopeTestTransport
     by default.
     """
+    transport_options = dict(use_datetime=use_datetime)
+    if six.PY3:
+        # use_builtin_types is only available since 3.3
+        transport_options['use_builtin_types'] = use_builtin_types
     if transport is None:
-        transport = ZopeTestTransport()
+        transport = ZopeTestTransport(**transport_options)
         transport.wsgi_app = wsgi_app
     if isinstance(transport, ZopeTestTransport):
         transport.handleErrors = handleErrors


### PR DESCRIPTION
`use_builtin_types` is in particular handy for the migration to Python 3 as it returns a `xmlrpc.client.Binary` instead of bytes. This class is not present in Python 2.