### PR TITLE
Fix handling of HTTP body in `.xmlrpc.testing`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 4.3.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix handling of HTTP body in ``.xmlrpc.testing`` to enable characters
+  beyond ASCII.
+  (`#11 <https://github.com/zopefoundation/zope.app.publisher/issues/11>`_)
 
 
 4.2.0 (2019-12-05)

--- a/src/zope/app/publisher/xmlrpc/README.rst
+++ b/src/zope/app/publisher/xmlrpc/README.rst
@@ -244,7 +244,7 @@ If you need to raise an error, the prefered way to do it is via an
   ...         self.request = request
   ...
   ...     def your_fault(self):
-  ...         return xmlrpclib.Fault(42, "It's your fault 😢!")
+  ...         return xmlrpclib.Fault(42, u"It's your fault \N{SNOWMAN}!")
 
 Now we'll register it as a view:
 
@@ -271,21 +271,18 @@ Now, when we call it, we get a proper XML-RPC fault:
 
   >>> try:
   ...     from xmlrpc.client import Fault
-  ...     expected = '<Fault 42: "It\'s your fault 😢!">'
+  ...     expected = '<Fault 42: "It\'s your fault \N{SNOWMAN}!">'
   ... except ImportError:  # PY2
   ...     from xmlrpclib import Fault
-  ...     expected = '<Fault 42: u"It\'s your fault \U0001f622!">'
+  ...     expected = '<Fault 42: u"It\'s your fault \u2603!">'
   >>> proxy = ServerProxy(wsgi_app, "http://mgr:mgrpw@localhost/")
   >>> # When dropping PY2 we can come back here to asserting the text of the
   >>> # exception:
   >>> try:
   ...     proxy.your_fault()
   ... except Fault as e:
-  ...     assert str(e) == expected, str(e)
-  ... except Exception as e:
-  ...     raise AssertionError('Raised %s instead of `Fault`!')
-  ... else:
-  ...     raise AssertionError('Nothing raised.')
+  ...     str(e) == expected
+  True
 
 
 DateTime values

--- a/src/zope/app/publisher/xmlrpc/README.rst
+++ b/src/zope/app/publisher/xmlrpc/README.rst
@@ -244,7 +244,7 @@ If you need to raise an error, the prefered way to do it is via an
   ...         self.request = request
   ...
   ...     def your_fault(self):
-  ...         return xmlrpclib.Fault(42, "It's your fault!")
+  ...         return xmlrpclib.Fault(42, "It's your fault 😢!")
 
 Now we'll register it as a view:
 
@@ -269,10 +269,23 @@ Now we'll register it as a view:
 
 Now, when we call it, we get a proper XML-RPC fault:
 
+  >>> try:
+  ...     from xmlrpc.client import Fault
+  ...     expected = '<Fault 42: "It\'s your fault 😢!">'
+  ... except ImportError:  # PY2
+  ...     from xmlrpclib import Fault
+  ...     expected = '<Fault 42: u"It\'s your fault \U0001f622!">'
   >>> proxy = ServerProxy(wsgi_app, "http://mgr:mgrpw@localhost/")
-  >>> proxy.your_fault()
-  Traceback (most recent call last):
-  xmlrpc.client.Fault: <Fault 42: "It's your fault!">
+  >>> # When dropping PY2 we can come back here to asserting the text of the
+  >>> # exception:
+  >>> try:
+  ...     proxy.your_fault()
+  ... except Fault as e:
+  ...     assert str(e) == expected, str(e)
+  ... except Exception as e:
+  ...     raise AssertionError('Raised %s instead of `Fault`!')
+  ... else:
+  ...     raise AssertionError('Nothing raised.')
 
 
 DateTime values

--- a/src/zope/app/publisher/xmlrpc/testing.py
+++ b/src/zope/app/publisher/xmlrpc/testing.py
@@ -76,10 +76,10 @@ class ZopeTestTransport(xmlrpclib.Transport):
                 headers)
 
         body = response.getBody()
-        if not isinstance(body, str):
+        if not isinstance(errmsg, bytes):
             # Python 3
-            body = body.decode("utf-8")
-        content = 'HTTP/1.0 ' + errmsg + '\n\n' + body
+            errmsg = errmsg.encode("ascii")
+        content = b'HTTP/1.0 ' + errmsg + b'\n\n' + body
 
         res = httplib.HTTPResponse(FakeSocket(content))
         res.begin()

--- a/src/zope/app/publisher/xmlrpc/testing.py
+++ b/src/zope/app/publisher/xmlrpc/testing.py
@@ -76,9 +76,10 @@ class ZopeTestTransport(xmlrpclib.Transport):
                 headers)
 
         body = response.getBody()
-        if not isinstance(errmsg, bytes):
-            # Python 3
-            errmsg = errmsg.encode("ascii")
+        body = body if isinstance(body, bytes) else body.encode('latin-1')
+        errmsg = (errmsg
+                  if isinstance(errmsg, bytes)
+                  else errmsg.encode('ascii'))  # HTTP response lines are ASCII
         content = b'HTTP/1.0 ' + errmsg + b'\n\n' + body
 
         res = httplib.HTTPResponse(FakeSocket(content))

--- a/src/zope/app/publisher/xmlrpc/testing.py
+++ b/src/zope/app/publisher/xmlrpc/testing.py
@@ -21,8 +21,7 @@ class FakeSocket(object):
     def makefile(self, mode, bufsize=None):
         assert 'b' in mode
         data = self.data
-        if not isinstance(data, bytes):
-            data = data.encode('iso-8859-1')
+        assert isinstance(data, bytes)
         return BytesIO(data)
 
 


### PR DESCRIPTION
This enables to use characters beyond ASCII.
Fixes #11.