### PR TITLE
Set Host header in .xmlrpc.testing.ServerProxy

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,12 @@
  CHANGES
 =========
 
-4.3.2 (unreleased)
+4.4.0 (unreleased)
 ==================
+
+- Make ``.xmlrpc.testing.ServerProxy`` set an appropriate ``Host`` header in
+  its request, allowing WSGI applications that serve multiple virtual hosts
+  to tell the difference between them.
 
 - Nothing changed yet.
 

--- a/src/zope/app/publisher/xmlrpc/README.rst
+++ b/src/zope/app/publisher/xmlrpc/README.rst
@@ -107,6 +107,41 @@ credentials:
   ...
   zope.security.interfaces.Unauthorized: ...
 
+`ServerProxy` sets an appropriate `Host` header, so applications that serve
+multiple virtual hosts can tell the difference:
+
+  >>> class Headers:
+  ...     def host(self):
+  ...         return self.request.headers.get("Host")
+
+  >>> from zope.configuration import xmlconfig
+  >>> ignored = xmlconfig.string("""
+  ... <configure
+  ...     xmlns="http://namespaces.zope.org/zope"
+  ...     xmlns:xmlrpc="http://namespaces.zope.org/xmlrpc"
+  ...     >
+  ...   <!-- We only need to do this include in this example,
+  ...        Normally the include has already been done for us. -->
+  ...   <include package="zope.app.publisher.xmlrpc" file="meta.zcml" />
+  ...   <include package="zope.security" file="meta.zcml" />
+  ...
+  ...   <class class="zope.app.publisher.xmlrpc.README.Headers">
+  ...       <allow attributes="host" />
+  ...   </class>
+  ...
+  ...   <xmlrpc:view
+  ...       name="headers"
+  ...       for="zope.site.interfaces.IFolder"
+  ...       methods="host"
+  ...       class="zope.app.publisher.xmlrpc.README.Headers"
+  ...       />
+  ... </configure>
+  ... """)
+
+  >>> proxy = ServerProxy(wsgi_app, "http://mgr:mgrpw@nonsense.test:81/headers")
+  >>> print(proxy.host())
+  nonsense.test:81
+
 
 Named XML-RPC Views
 -------------------

--- a/src/zope/app/publisher/xmlrpc/testing.py
+++ b/src/zope/app/publisher/xmlrpc/testing.py
@@ -50,6 +50,7 @@ class ZopeTestTransport(xmlrpclib.Transport):
         request += "Content-Type: text/xml\n"
 
         host, extra_headers, _x509 = self.get_host_info(host)
+        request += "Host: %s\n" % host
         if extra_headers:
             request += "Authorization: %s\n" % (
                 dict(extra_headers)["Authorization"],)


### PR DESCRIPTION
WSGI applications that serve multiple virtual hosts need a way to tell
the difference between them in incoming requests.  (For example, we use
such a setup in Launchpad.)  Setting the Host header allows this to
work.